### PR TITLE
chore(ci): bump Go to 1.26 and golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
       - name: set up golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: check out code
         uses: actions/checkout@v7
       - name: run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.4.0
+          version: v2.12.2
       - name: unit test
         run: go test -covermode=atomic -coverprofile=profile.cov -v ./...
       - name: upload coverage to codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.12.2
+          version: v2.11.4
       - name: unit test
         run: go test -covermode=atomic -coverprofile=profile.cov -v ./...
       - name: upload coverage to codecov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: false
       - name: run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.4.0
+          version: v2.12.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.12.2
+          version: v2.11.4

--- a/.github/workflows/testcov.yml
+++ b/.github/workflows/testcov.yml
@@ -7,7 +7,7 @@ jobs:
       - name: set up golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: check out code
         uses: actions/checkout@v7
       - name: unit test


### PR DESCRIPTION
k8s.io/* 0.36.x modules require Go 1.26 (their go.mod declares `go 1.26.0`). The CI workflows were pinned to Go 1.25, causing dependabot PRs bumping k8s.io packages (#448, #444, #427) to fail:

```
compile: version "go1.26.0" does not match go tool version "go1.25.11"
Error: can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.0)
```

This bumps setup-go to 1.26 and golangci-lint to v2.12.2 (built with Go 1.26) in lint.yml, testcov.yml, and ci.yml. Unblocks the pending k8s.io dependabot PRs.